### PR TITLE
Missing packages under Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -62,13 +62,14 @@ Suggests:
     biomaRt,
     dorothea,
     viper,
-    sesame,
     stageR,
     BiocFileCache,
     png,
     htmltools,
     knitr,
-    jpeg
+    jpeg,
+    sesame,
+    BSgenome.Hsapiens.UCSC.hg38
 VignetteBuilder: knitr
 BugReports: https://github.com/TransBioInfoLab/MethReg/issues/
 RoxygenNote: 7.1.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -62,6 +62,7 @@ Suggests:
     biomaRt,
     dorothea,
     viper,
+    sesame,
     stageR,
     BiocFileCache,
     png,


### PR DESCRIPTION
Hi, while running revdep check on my 'matrixStats' package, 'MethReg' fail `R CMD check --as-cran` with:

```
* checking examples ... ERROR
Running examples in ‘MethReg-Ex.R’ failed
The error most likely occurred in:

> ### Name: create_triplet_distance_based
> ### Title: Map DNAm to target genes using distance approaches, and TF to
> ###   the DNAm region using JASPAR2020 TFBS.
> ### Aliases: create_triplet_distance_based
> 
> ### ** Examples
> 
> regions.names <- c("chr3:189631389-189632889","chr4:43162098-43163498")
> triplet <- create_triplet_distance_based(
+    region = regions.names,
+    motif.search.window.size = 500,
+    target.method = "closest.gene"
+ )
Finding target genes
Removing regions overlapping promoter regions
o Get promoter regions for hg38
o Remove promoter regions
Looking for TFBS
Error in h(simpleError(msg, call)) : 
  error in evaluating the argument 'x' in selecting a method for function 'assay': BSgenome.Hsapiens.UCSC.hg38 package is not currently installed.
  You first need to install it, which you can do with:
      library(BiocManager)
      install("BSgenome.Hsapiens.UCSC.hg38")
Calls: create_triplet_distance_based -> get_tf_in_region
Execution halted
* checking for unstated dependencies in ‘tests’ ... OK
* checking tests ... ERROR
  Running ‘testthat.R’
Running the tests in ‘tests/testthat.R’ failed.
Last 50 lines of output:
  |                                                    |  0%                      
  |====================================================|100% ~0 s remaining       
  |====================================================|100%                      Completed after 2 s 
  
  |                                                    |  0%                      
  |====================================================|100% ~0 s remaining       
  |====================================================|100%                      Completed after 2 s 
  
  |                                                    |  0%                      ── Warning (test-stratified_model.R:26:5): stratified_model works ──────────────
  'rlm' failed to converge in 100 steps
  
  
  |====================================================|100% ~0 s remaining       
  |====================================================|100%                      Completed after 0 s 
  
  |                                                    |  0%                      
  |====================================================|100% ~0 s remaining       
  |====================================================|100%                      Completed after 0 s 
  ── ERROR (test-utils.R:19:5): map_probes_to_regions changes probes cpgs to regio
  Error: sesame package is needed for this function to work. Please install it.
  Backtrace:
      █
   1. └─MethReg:::map_probes_to_regions(dna.met.chr21[1:2, ]) test-utils.R:19:4
   2.   └─MethReg::get_met_probes_info(genome, arrayType)
   3.     └─MethReg:::check_package("sesame")
   4.       └─base::suppressMessages(...)
   5.         └─base::withCallingHandlers(...)
  
  ── ERROR (test-utils.R:52:5): make_dnam_se returns a SE with regions ───────────
  Error: sesame package is needed for this function to work. Please install it.
  Backtrace:
      █
   1. └─MethReg::make_dnam_se(dna.met.chr21) test-utils.R:52:4
   2.   └─MethReg::get_met_probes_info(genome = genome, arrayType = arrayType)
   3.     └─MethReg:::check_package("sesame")
   4.       └─base::suppressMessages(...)
   5.         └─base::withCallingHandlers(...)
  
  ══ testthat results  ═══════════════════════════════════════════════════════════
  ERROR (test-create_triplet_distance_based.R:2:5): create_triplet_distance_based runs
  ERROR (test-filter_by_quantile.R:28:5): filter_dnam_by_quant_diff handles NAs for a SE
  FAILURE (test-get_promoter_avg.R:4:5): get_promoter_avg throws error if not promoter regions/probes
  ERROR (test-get_tf_in_region.R:5:5): get_tf_in_region is able to scan
  ERROR (test-get_tf_in_region.R:18:5): get_tf_in_region accepts granges as input
  Warning (test-plot_stratified_model.R:29:5): plot_interaction_model return a ggplot object
  Warning (test-stratified_model.R:26:5): stratified_model works
  ERROR (test-utils.R:19:5): map_probes_to_regions changes probes cpgs to regions
  ERROR (test-utils.R:52:5): make_dnam_se returns a SE with regions
  
  [ FAIL 7 | WARN 2 | SKIP 0 | PASS 147 ]
  Error: Test failures
  Execution halted
```

You can reproduce this yourself by running `R CMD check` with the `--as-cran` option, which causes the package to be tested in a sandbox with only declared packages dependencies available on the package library path.  This helps guarantee that everything is declared that should be declared.

This PR adds the two missing packages under `Suggests:`.